### PR TITLE
Clean up Ktlint rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,15 +10,7 @@ trim_trailing_whitespace = true
 max_line_length = off
 
 [*.{kt,kts}]
-ij_kotlin_align_multiline_parameters = true
-ij_kotlin_allow_trailing_comma = true
-ij_kotlin_allow_trailing_comma_on_call_site = true
-ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^
-ij_kotlin_line_comment_add_space = true
-ij_kotlin_space_before_when_parentheses = false
-ij_kotlin_wrap_elvis_expressions = 1
 max_line_length = 120
-ktlint_functional_experimental_trailing-comma-on-call-site = enabled
 
-# Do not use function expression body
+# Do not force function expression body
 ktlint_standard_function-expression-body = disabled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("maven-publish")
     kotlin("jvm") version "2.1.10"
     kotlin("plugin.spring") version "2.1.10"
-    id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
+    id("org.jlleitschuh.gradle.ktlint") version "13.1.0"
 }
 
 group = "no.fintlabs"
@@ -65,15 +65,6 @@ tasks.named<Jar>("jar") {
 
 java {
     withSourcesJar()
-}
-
-ktlint {
-    version.set("1.7.1")
-    ignoreFailures.set(false)
-    outputToConsole.set(true)
-    filter {
-        exclude("**/generated/**")
-    }
 }
 
 tasks.named("check") {


### PR DESCRIPTION
All rules removed from .editorconfig were set to their default value. The ktlint block removed from build.gradle.kts also just default values.