### PR TITLE
FFS-2224 Bump no.novari:kafka til versjon med tracing-støtte

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-autoconfigure")
     api("org.springframework.boot:spring-boot-starter-oauth2-client")
 
-    api("no.novari:kafka:6.3.0-rc-1")
+    api("no.novari:kafka:6.3.0-rc-2")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     kapt("org.springframework.boot:spring-boot-configuration-processor")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-autoconfigure")
     api("org.springframework.boot:spring-boot-starter-oauth2-client")
 
-    api("no.novari:kafka:6.2.0")
+    api("no.novari:kafka:6.3.0-rc-1")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     kapt("org.springframework.boot:spring-boot-configuration-processor")


### PR DESCRIPTION
## Sammendrag

- Bumper `no.novari:kafka` fra `6.2.0` til en RC med Kafka-sporing (fra FFS-2221)
- `flyt-web-resource-server` eksponerer denne som `api`-avhengighet til alle nedstrøms-konsumenter og bruker den selv aktivt i `SourceApplicationAuthorizationRequestService` (Kafka request/reply-oppslag for eksterne klienter)
- Uten denne bumpen ville apper som kun får `no.novari:kafka` via dette biblioteket (uten egen `flyt-kafka`-avhengighet, f.eks. `fint-flyt-authorization-service`) aldri fått sporingsbryteren

Del av OpenTelemetry-tracing-epicen (FFS-2196), avdekket under utrulling til FFS-2224-appene.

**Merk:** Oppdateres til final release av `fint-kafka` når FFS-2223–FFS-2226 er verifisert.